### PR TITLE
Add support for Xiaomi Air Purifier 4 (zhimi.airpurifier.mb5)

### DIFF
--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
@@ -134,7 +134,7 @@ module.exports = class extends Device {
     return this.miotSetProperty('physical-controls-locked:physical-controls-locked', v);
   }
 
-  setAqiUpateInterval() {
+  setAqiUpateInterval(v) {
     return this.miotSetProperty('aqi:aqi-updata-heartbeat', v);
   }
 

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
@@ -110,10 +110,6 @@ module.exports = class extends Device {
     return this.miotSetProperty('air-purifier:mode', v);
   }
 
-  setFavSpeed(v) { // 300-2200
-    return this.miotSetProperty('custom-service:favorite-speed', v);
-  }
-
   setFanLevel(v) { // 1-3
     return this.miotSetProperty('air-purifier:fan-level', v);
   }

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
@@ -134,7 +134,8 @@ module.exports = class extends Device {
     return this.miotSetProperty('physical-controls-locked:physical-controls-locked', v);
   }
 
-  setAqiUpateInterval(v) {
+  // Sets duration for which the PM2.5-sensor provides real-time data. Duration is automatically decreased until "0" is reached
+  setAqiRealtimeUpdateDuration(v) {
     return this.miotSetProperty('aqi:aqi-updata-heartbeat', v);
   }
 

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb3.js
@@ -94,7 +94,7 @@ module.exports = class extends Device {
     return this.properties['indicator-light:brightness'];
   }
 
-  getAqiUpateInterval() {
+  getAqiRealtimeUpdateDuration() {
     return this.properties['aqi:aqi-updata-heartbeat'];
   }
 

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
@@ -1,32 +1,30 @@
 const Device = require('../device-miio');
-//edited and checked for full funcionality by Wildbill-Z
+
 module.exports = class extends Device {
 
-  static model = 'zhimi.airpurifier.mb3';
-  static name = 'Mi Air Purifier 3H';
+  static model = 'zhimi.airpurifier.mb5';
+  static name = 'Mi Air Purifier 4';
   static image = 'https://cdn.awsde0.fds.api.mi-img.com/miio.files/developer_15504816557tej1pj6.png';
 
   constructor(opts) {
     super(opts);
 
-    this._miotSpecType = 'urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-mb3:2';
+    this._miotSpecType = 'urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-mb5:1';
     this._propertiesToMonitor = [
       'air-purifier:fault',
       'air-purifier:on',
       'air-purifier:fan-level',
       'air-purifier:mode',
+      'air-purifier:anion',
       'environment:pm2.5-density',
       'environment:relative-humidity',
       'environment:temperature',
       'filter:filter-life-level',
       'filter:filter-used-time',
+      'filter:filter-left-time',
       'alarm:alarm',
-      'indicator-light:brightness',
-      'indicator-light:on',
-      'motor-speed:motor-speed',
-      'motor-speed:motor-set-speed',
-      'motor-speed:favorite-fan-level',
-      'use-time:use-time',
+      'custom-service:favorite-level',
+      'physical-controls-locked:brightness',
       'physical-controls-locked:physical-controls-locked',
       'aqi:aqi-updata-heartbeat'];
   }
@@ -40,24 +38,34 @@ module.exports = class extends Device {
     if (mode === 0) return 'auto';
     if (mode === 1) return 'sleep';
     if (mode === 2) return 'favorite';
-    if (mode === 3) return 'none';
+    if (mode === 3) return 'manual';
+    return undefined;
+  }
+
+  getFault() {
+    const fault = this.properties['air-purifier:fault'];
+    if (fault === 0) return 'No Faults"';
+    if (fault === 1) return 'Sensor PM Error';
+    if (fault === 2) return 'Temp Error';
+    if (fault === 3) return 'Hum Error';
+    if (fault === 4) return 'No Filter';
     return undefined;
   }
 
   getFanLevel() { // 1 - 3
-    return this.properties['air-purifier:fan-level'];
+    const fanLevel = this.properties['air-purifier:fan-level'];
+    if (fanLevel === 1) return 'Level1';
+    if (fanLevel === 2) return 'Level2';
+    if (fanLevel === 3) return 'Level3';
+    return undefined;
   }
 
-  getFavLevel() { // 1 - 9
-    return this.properties['motor-speed:favorite-fan-level'];
+  getFavLevel() { // 0 - 11
+    return this.properties['custom-service:favorite-level'];
   }
 
-  getSpeed() {
-    return this.properties['motor-speed:motor-speed'];
-  }
-
-  getSetSpeed() {
-    return this.properties['motor-speed:motor-set-speed'];
+  getAnion() {
+    return this.properties['air-purifier:anion'];
   }
 
   getTemperature() {
@@ -74,24 +82,15 @@ module.exports = class extends Device {
   }
 
   getFilterRemaining() {
-    const filterTotal = this.properties['filter:filter-life-level'];
-    const filterUsed = this.properties['filter:filter-used-time'];
-    if (filterTotal > 0 && filterUsed >= 0) {
-      return Math.max((1 - filterUsed / filterTotal) * 100, 0);
-    }
-    return undefined;
+    return this.properties['filter:filter-left-time'];
   }
 
   getBuzzer() {
     return this.properties['alarm:alarm'];
   }
 
-  getUseTime() {
-    return this.properties['use-time:use-time'];
-  }
-
   getLcdBrightness() {
-    return this.properties['indicator-light:brightness'];
+    return this.properties['physical-controls-locked:brightness'];
   }
 
   getAqiUpateInterval() {
@@ -110,24 +109,31 @@ module.exports = class extends Device {
     return this.miotSetProperty('air-purifier:mode', v);
   }
 
-  setFavSpeed(v) { // 300-2200
+  setFavSpeed(v) { // 200-2300
     return this.miotSetProperty('custom-service:favorite-speed', v);
   }
 
   setFanLevel(v) { // 1-3
+    if (v === 'Level1') v = 1;
+    else if (v === 'Level2') v = 2;
+    else if (v === 'Level3') v = 3;
     return this.miotSetProperty('air-purifier:fan-level', v);
   }
 
-  setFavLevel(v) { // 1 - 9
-    return this.miotSetProperty('motor-speed:favorite-fan-level', v);
+  setFavLevel(v) { // 0 - 11
+    return this.miotSetProperty('custom-service:favorite-level', v);
+  }
+
+  setAnion(v) {
+    return this.miotSetProperty('air-purifier:anion', v);
   }
 
   setBuzzer(v) {
     return this.miotSetProperty('alarm:alarm', v);
   }
 
-  setLcdBrightness(v) { // 0-brightest, 1-glimmer, 2-led_closed
-    return this.miotSetProperty('indicator-light:brightness', v);
+  setLcdBrightness(v) { // 0-Close, 1-Bright, 2-Brightest
+    return this.miotSetProperty('physical-controls-locked:brightness', v);
   }
 
   setChildLock(v) {

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
@@ -140,7 +140,7 @@ module.exports = class extends Device {
     return this.miotSetProperty('physical-controls-locked:physical-controls-locked', v);
   }
 
-  setAqiUpateInterval() {
+  setAqiUpateInterval(v) {
     return this.miotSetProperty('aqi:aqi-updata-heartbeat', v);
   }
 

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
@@ -93,7 +93,7 @@ module.exports = class extends Device {
     return this.properties['screen:brightness'];
   }
 
-  getAqiUpateInterval() {
+  getAqiRealtimeUpdateDuration() {
     return this.properties['aqi:aqi-updata-heartbeat'];
   }
 

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
@@ -24,7 +24,7 @@ module.exports = class extends Device {
       'filter:filter-left-time',
       'alarm:alarm',
       'custom-service:favorite-level',
-      'physical-controls-locked:brightness',
+      'screen:brightness',
       'physical-controls-locked:physical-controls-locked',
       'aqi:aqi-updata-heartbeat'];
   }
@@ -90,7 +90,7 @@ module.exports = class extends Device {
   }
 
   getLcdBrightness() {
-    return this.properties['physical-controls-locked:brightness'];
+    return this.properties['screen:brightness'];
   }
 
   getAqiUpateInterval() {
@@ -133,7 +133,7 @@ module.exports = class extends Device {
   }
 
   setLcdBrightness(v) { // 0-Close, 1-Bright, 2-Brightest
-    return this.miotSetProperty('physical-controls-locked:brightness', v);
+    return this.miotSetProperty('screen:brightness', v);
   }
 
   setChildLock(v) {

--- a/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
+++ b/DefinitionfilesForNode-Mihome/zhimi.airpurifier.mb5.js
@@ -140,7 +140,8 @@ module.exports = class extends Device {
     return this.miotSetProperty('physical-controls-locked:physical-controls-locked', v);
   }
 
-  setAqiUpateInterval(v) {
+  // Sets duration for which the PM2.5-sensor provides real-time data. Duration is automatically decreased until "0" is reached
+  setAqiRealtimeUpdateDuration(v) {
     return this.miotSetProperty('aqi:aqi-updata-heartbeat', v);
   }
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Skript zur Steuerung von bisher nicht unterstützten Xiaomi Geräten in Iobroker
 * Xiaomi Air Purifier 2H          - zhimi.airpurifier.mc2   - (voll/voll)
 * Mi Air Purifier Pro H           - zhimi.airpurifier.vb2   - (voll/voll)
 * Mi Air Purifier 3C              - zhimi.airpurifier.mb4   - (voll/voll)
+* Mi Air Purifier 4               - zhimi.airpurifier.mb5   - (voll/voll)
 * Mi Air Purifier Pro             - zhimi.airpurifier.v7    - (voll/voll)
 * Air Purifier                    - zhimi.airpurifier.ma4   - (ready to test)
 * Xiaomi Air Purifier 2S          - zhimi.airpurifier.mc1   - (voll/voll)


### PR DESCRIPTION
This has been tested and verified as I've got this device myself. Everything works fine for me as far as I can tell. 😉 

Also, I've added "aqi:aqi-updata-heartbeat" to the Air Purifier 3H definition file to be able to force the PM2.5-sensor into real-time measurement mode (like the Xiaomi home app does).